### PR TITLE
supported Xcode8 swift 2.3

### DIFF
--- a/Pod/Classes/Credentials.swift
+++ b/Pod/Classes/Credentials.swift
@@ -18,7 +18,7 @@ public struct Credentials: Equatable {
 	public let identityURL: NSURL
 	
 	public var userID: String? {
-		return identityURL.absoluteString.componentsSeparatedByString("/").last 
+		return identityURL.absoluteString?.componentsSeparatedByString("/").last
 	}
 	
 	

--- a/Pod/Classes/SalesforceAPI.swift
+++ b/Pod/Classes/SalesforceAPI.swift
@@ -185,11 +185,11 @@ extension SalesforceAPI {
 		case .Identity:
 			URL = credentials.identityURL
 		case .NextQueryResult, .Custom:
-			URL = credentials.instanceURL.URLByAppendingPathComponent(route.URI)
+			URL = credentials.instanceURL.URLByAppendingPathComponent(route.URI)!
 		case .ApexRest:
-			URL = credentials.instanceURL.URLByAppendingPathComponent("/services/apexrest\(route.URI)")
+			URL = credentials.instanceURL.URLByAppendingPathComponent("/services/apexrest\(route.URI)")!
 		default:
-			URL = credentials.instanceURL.URLByAppendingPathComponent("/services/data/v\(version)\(route.URI)")
+			URL = credentials.instanceURL.URLByAppendingPathComponent("/services/data/v\(version)\(route.URI)")!
 		}
 		
 		let req = NSMutableURLRequest(URL: URL)


### PR DESCRIPTION
Fixed compile error with Xcode8 & swift2.3.

I couldn't compile SwiftlySalesforce using Xcode8 & swift2.3 and updating Podfile like below

```ruby
post_install do |installer|
  installer.pods_project.targets.each do |target|
    target.build_configurations.each do |config|
      config.build_settings['SWIFT_VERSION'] = '2.3'
    end
  end
end
```