### PR TITLE
Support for registering with Salesforce Notification services

### DIFF
--- a/Example/SwiftlySalesforce/AppDelegate.swift
+++ b/Example/SwiftlySalesforce/AppDelegate.swift
@@ -8,9 +8,10 @@
 
 import UIKit
 import SwiftlySalesforce
+import UserNotifications
 
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate, LoginDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate, LoginDelegate {
 
 	var window: UIWindow?
 	
@@ -20,6 +21,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, LoginDelegate {
 
 	func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 		configureSalesforce(consumerKey: consumerKey, redirectURL: redirectURL)
+        
+        //uncomment if you want to receive push notifications, including those 
+        //from salesforce's universal notification service
+        //registerForRemoteNotification()
 		return true
 	}
 	
@@ -27,4 +32,54 @@ class AppDelegate: UIResponder, UIApplicationDelegate, LoginDelegate {
 		handleRedirectURL(url: url)
 		return true
 	}
+    
+    //
+    //MARK: Push notifications
+    // This code below is only required if you care about push notifications.
+    //
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        let deviceTokenString = deviceToken.reduce("", {$0 + String(format: "%02X", $1)})
+        salesforce.registerForSalesforceNotifications(devicetoken: deviceTokenString)
+            .then {
+                (result) -> () in
+                print("successfully registered for salesforce notifications")
+            }.catch {
+                error in
+                print(error)
+        }
+    }
+    
+    //Called when a notification is delivered to a foreground app.
+    @available(iOS 10.0, *)
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        print("User Info = ",notification.request.content.userInfo)
+        completionHandler([.alert, .badge, .sound])
+    }
+    
+    //Called to let your app know which action was selected by the user for a given notification.
+    @available(iOS 10.0, *)
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        print("didReceive = ",response.notification.request.content.userInfo)
+        
+        completionHandler()
+        
+    }
+    
+    func registerForRemoteNotification() {
+        if #available(iOS 10.0, *) {
+            let center  = UNUserNotificationCenter.current()
+            center.delegate = self
+            center.requestAuthorization(options: [.sound, .alert, .badge]) { (granted, error) in
+                if error == nil{
+                    UIApplication.shared.registerForRemoteNotifications()
+                }
+            }
+        }
+        else {
+            UIApplication.shared.registerUserNotificationSettings(UIUserNotificationSettings(types: [.sound, .alert, .badge], categories: nil))
+            UIApplication.shared.registerForRemoteNotifications()
+        }
+        UIApplication.shared.applicationIconBadgeNumber = 0
+    }
+
 }

--- a/Example/SwiftlySalesforce/AppDelegate.swift
+++ b/Example/SwiftlySalesforce/AppDelegate.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 import SwiftlySalesforce
-import UserNotifications
+import UserNotifications 
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate, LoginDelegate {

--- a/Pod/Classes/Salesforce.swift
+++ b/Pod/Classes/Salesforce.swift
@@ -248,7 +248,7 @@ open class Salesforce {
         let headers = ["Content-Type" : "application/json"]
         let params = ["ConnectionToken" : devicetoken, "ServiceType" : "Apple" ]
         return custom(method: .post, path: "/services/data/v\(version)/sobjects/MobilePushServiceDevice", parameters: params, headers: headers)
-    }
+    } 
     
 
 	

--- a/Pod/Classes/Salesforce.swift
+++ b/Pod/Classes/Salesforce.swift
@@ -240,6 +240,17 @@ open class Salesforce {
 		}
 		return request(requestBuilder: builder, jsonDeserializer: deserializer)
 	}
+    
+    /// Use this method to register your device to receive push notifications from the Salesforce Universal Push Notification service
+    /// - Parameter devicetoken: the device token returned from a successful UIApplication.shared.registerForRemoteNotification() invocation.
+    /// - Returns: Promise of Any Type; result will either be success, or failure message
+    open func registerForSalesforceNotifications(devicetoken: String) -> Promise<Any> {
+        let headers = ["Content-Type" : "application/json"]
+        let params = ["ConnectionToken" : devicetoken, "ServiceType" : "Apple" ]
+        return custom(method: .post, path: "/services/data/v\(version)/sobjects/MobilePushServiceDevice", parameters: params, headers: headers)
+    }
+    
+
 	
 	fileprivate func request<T,U>(requestBuilder: @escaping (AuthData) throws -> URLRequest, jsonDeserializer: @escaping (U) throws -> T) -> Promise<T> {
 		


### PR DESCRIPTION
in order to receive push notifications from salesforce's universal notification framework, you need to register your devicetoken.