### PR TITLE
Adding the choice to show - or not - the login view after logging out

### DIFF
--- a/SwiftlySalesforce/Classes/LoginDelegate.swift
+++ b/SwiftlySalesforce/Classes/LoginDelegate.swift
@@ -98,6 +98,35 @@ extension LoginDelegate {
 			}
 		}
 	}
+	
+	/// Call this to initiate logout process, having ability to show - or not - the login view
+	/// Revokes OAuth2 refresh and/or access token, then replaces - or not -
+	/// the current root view controller with a Safari view controller for login
+	/// - Parameter connectedApp: Connected App from which the current user will log out
+	/// - Parameter showLoginView: Boolean to show the login view after the logout process
+	/// - Returns: Promise<Void>; chain to this for custom post-logout actions
+	public func logout(from connectedApp: ConnectedApp, showLoginView: Bool) -> Promise<Void> {
+		return Promise<Void> {
+			fulfill, reject in
+			firstly {
+				connectedApp.revoke()
+				}.then {
+					() -> () in
+					if showLoginView {
+						if let loginURL = try? connectedApp.loginURL(), let window = UIApplication.shared.keyWindow {
+							// Replace current root view controller with Safari view controller for login
+							let loginVC = SafariLoginViewController(url: loginURL)
+							loginVC.replacedRootViewController = window.rootViewController
+							window.rootViewController = loginVC
+						}
+					}
+					fulfill(())
+				}.catch {
+					error -> () in
+					reject(error)
+			}
+		}
+	}
 }
 
 // MARK: - Extension constrained to UIApplicationDelegate


### PR DESCRIPTION
Adding a boolean showLoginView when logging out to give the user the choice of showing the login view or not after the logout process.