### PR TITLE
Add macOS platform version for capabilities

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,7 @@ let package = Package(
     name: "SwiftlySalesforce",
     platforms: [
         .iOS(.v15),
+        .macOS(.v12)
     ],
     products: [
         .library(


### PR DESCRIPTION
SwiftlySalesforce has smooth integrations for macOS apps as well, this is to avoid the errors of any version requirements